### PR TITLE
Revert "Update managed.logback to v1.4.11 (#44)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 micronaut = "4.1.3"
 
 managed-log4j = "2.20.0"
-managed-logback = "1.4.11"
+managed-logback = "1.4.8"
 managed-slf4j = "2.0.9"
 
 [libraries]


### PR DESCRIPTION
This reverts commit eb78f631d42e1a6f66ce9a8001091c0ff6ca0eec.

Unfortunately, Logback 1.4.9, 1.4.10, and 1.4.11 include breaking changes. 