### PR TITLE
logback to v1.4.11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 micronaut = "4.1.3"
 
 managed-log4j = "2.20.0"
-managed-logback = "1.4.8"
+managed-logback = "1.4.11"
 managed-slf4j = "2.0.9"
 
 [libraries]


### PR DESCRIPTION
This reverts commit bea505134f69b621da791f9c4ccc49a211dce97a.

I think it is better to get back to 1.4.11 and release Micronaut Framework 4.1.1 with logback 4.1.11 in core and lgoging. Since, it is fixed in core https://github.com/micronaut-projects/micronaut-core/pull/9857